### PR TITLE
2.distsn.org has gone.

### DIFF
--- a/blockchain.json
+++ b/blockchain.json
@@ -26,12 +26,6 @@
 		},
 
 		{
-			"name": "2.distsn.org",
-			"domain": 	"freespeech.firedragonstudios.com",
-			"reasons": ["spam"]
-		},
-
-		{
 			"name": "yiff.rocks",
 			"domain": 	"yiff.rocks",
 			"reasons": ["harrassment", "FVZ"]


### PR DESCRIPTION
https://2.distsn.org has gone.