### PR TITLE
Add comm.network to list of obvious freeze-peach instances.

### DIFF
--- a/list/list.md
+++ b/list/list.md
@@ -92,7 +92,7 @@ These typically won't have pages of their own because it's normally self-evident
 * **libertarianism.club**
 * **npf.mlpol.net**
 * **pleroma.cucked.me**
-
+* **comm.network**
 
 #### Less obvious ones
 


### PR DESCRIPTION
This should be obvious based on their about page; I can add screenshots of the
admin slipping in to another user's mentions to abuse them if necessary, but
I'd rather not bother.